### PR TITLE
update dependencies for compatibility with Emacs 27

### DIFF
--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -7,7 +7,7 @@
 ;; Website: https://activitywatch.net
 ;; Homepage: https://github.com/pauldub/activity-watch-mode
 ;; Keywords: calendar, comm
-;; Package-Requires: ((emacs "24") (projectile "0") (request "0") (json "0") (cl "0"))
+;; Package-Requires: ((emacs "25") (projectile "0") (request "0") (json "0") (cl-lib "0"))
 ;; Version: 1.0.2
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -34,14 +34,14 @@
 ;; Requires request.el (https://tkf.github.io/emacs-request/)
 ;;
 
-;;; Dependencies: request, projectile, json, cl
+;;; Dependencies: request, projectile, json, cl-lib
 
 ;;; Code:
 
 (require 'ert)
 (require 'request)
 (require 'json)
-(require 'cl)
+(require 'cl-lib)
 
 (defconst activity-watch-version "1.0.0")
 (defconst activity-watch-user-agent "emacs-activity-watch")


### PR DESCRIPTION
[With Emacs 24.3](https://www.emacswiki.org/emacs/CommonLispForEmacs), `cl` was replaced by `cl-lib`.  Backwards compatibility for `cl` has been discontinued in Emacs 27.  This PR updates the package to use `cl-lib`, making it compatible with Emacs 25+.