### PR TITLE
Stop clobbering match data in first-change-hook

### DIFF
--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -132,9 +132,10 @@ Argument TIME time at which the heartbeat was computed."
 
 (defun activity-watch--save ()
   "Send save notice to Activity-Watch."
-  (when (and (buffer-file-name (current-buffer))
-             (not (auto-save-file-name-p (buffer-file-name (current-buffer)))))
-    (activity-watch--call)))
+  (save-match-data
+    (when (and (buffer-file-name (current-buffer))
+               (not (auto-save-file-name-p (buffer-file-name (current-buffer)))))
+      (activity-watch--call))))
 
 (defun activity-watch--start-timer ()
   "Start timers for heartbeat submission and idling."


### PR DESCRIPTION
The save function seems to be doing operations that clobber the search/replace match data, and thus
needs to use `save-match-data` to correctly save and restore it. Without doing this,
search-and-replace in a buffer that hasn't yet been modified will fail after doing a single
replacement with an error like:

    replace-match-maybe-edit: Match data clobbered by buffer modification hooks

Fixes: #11 