### PR TITLE
Customizable project name detection process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ## Installation
 
-Heads Up! ActivityWatch depends on [request.el](https://tkf.github.io/emacs-request/) and [Projectile](https://github.com/bbatsov/projectile) being installed to work correctly.
+Heads Up! ActivityWatch depends on [request.el](https://tkf.github.io/emacs-request/) being installed to work correctly.
+
+It optionally depends on [Projectile](https://github.com/bbatsov/projectile) and [Magit](https://magit.vc) to detect project names.
 
 1. Install activity-watch-mode for Emacs using [MELPA](https://melpa.org/#/activity-watch-mode).
 
@@ -24,6 +26,11 @@ Enable ActivityWatch for the current buffer by invoking `M-x activity-watch-mode
 ## Configuration
 
 Set variable `activity-watch-api-host` to your activity watch local instance (default to `http://localhost:5600`).
+
+By default, the extension will try to infer the name of the project by consulting Projectile and Magit. Users can add resolution methods by defining functions in the form `activity-watch-project-name-<NAME>` and then adding `'NAME` to the list of resolvers `activity-watch-project-name-resolvers`. See its documentation for a list of predefined resolvers.
+
+The default project name used when a proper one cannot be determined is "unknown" and can be customized via `activity-watch-project-name-default`.
+
 
 ## Acknowledgments
 

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -212,12 +212,12 @@ specified in `activity-watch-project-name-resolvers'."
 (defun activity-watch--create-heartbeat (time)
   "Create heartbeart to sent to the activity watch server.
 Argument TIME time at which the heartbeat was computed."
-  (let ((project-name (projectile-project-name))
+  (let ((project-name (activity-watch--get-project))
         (file-name (buffer-file-name (current-buffer))))
     `((timestamp . ,(ert--format-time-iso8601 time))
       (duration . 0)
       (data . ((language . ,(if (activity-watch--s-blank (symbol-name major-mode)) "unknown" major-mode))
-               (project . ,(if (activity-watch--s-blank project-name) "unknown" project-name))
+               (project . ,project-name)
                (file . ,(if (activity-watch--s-blank file-name) "unknown" file-name)))))))
 
 

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -42,6 +42,7 @@
 (require 'request)
 (require 'json)
 (require 'cl-lib)
+(require 'subr-x)
 
 (defconst activity-watch-version "1.0.0")
 (defconst activity-watch-user-agent "emacs-activity-watch")

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -7,7 +7,7 @@
 ;; Website: https://activitywatch.net
 ;; Homepage: https://github.com/pauldub/activity-watch-mode
 ;; Keywords: calendar, comm
-;; Package-Requires: ((emacs "25") (projectile "0") (request "0") (json "0") (cl-lib "0"))
+;; Package-Requires: ((emacs "25") (request "0") (json "0") (cl-lib "0"))
 ;; Version: 1.0.2
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -34,7 +34,7 @@
 ;; Requires request.el (https://tkf.github.io/emacs-request/)
 ;;
 
-;;; Dependencies: request, projectile, json, cl-lib
+;;; Dependencies: request, json, cl-lib
 
 ;;; Code:
 

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -304,6 +304,12 @@ Argument DEFER Wether initialization should be deferred."
   (activity-watch--stop-idle-timer))
 
 ;;;###autoload
+(defun activity-watch-refresh-project-name ()
+  "Recompute the name of the project for the current file."
+  (interactive)
+  (activity-watch--get-project t))
+
+;;;###autoload
 (define-minor-mode activity-watch-mode
   "Toggle Activity-Watch (Activity-Watch mode)."
   :lighter    " activity-watch"

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -206,7 +206,7 @@ specified in `activity-watch-project-name-resolvers'."
                                   (type . "app.editor.activity")))
              :headers '(("Content-Type" . "application/json"))
              :success (cl-function
-                       (lambda (&allow-other-keys)
+                       (lambda (&rest _ &allow-other-keys)
                          (setq activity-watch-bucket-created t))))))
 
 (defun activity-watch--create-heartbeat (time)


### PR DESCRIPTION
Fixes #4

This PR allows the user to specify multiple ways of detecting the name of the project. I have included multiple resolvers based on Projectile and Magit, as those are the primary tools I use for interacting with project structures. I believe the process for adding custom resolvers is easy and reasonably documented.

I also removed projectile from dependencies, as it is now an optional dependency and the package works fine without it installed.

There was also one error I found in the implementation of a request callback, which may have affected performance, so it would probably be good to ping the issues about slowing down Emacs and ask whether this patch changes anything.

Let me know if there is anything missing.