### PR TITLE
Support built-in `project.el` for getting project name

### DIFF
--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -75,7 +75,7 @@
   :type 'string
   :group 'activity-watch)
 
-(defcustom activity-watch-project-name-resolvers '(projectile magit-dir-force magit-origin)
+(defcustom activity-watch-project-name-resolvers '(projectile project magit-dir-force magit-origin)
   "List of resolvers used to find the project name.
 
 When determining the name of a project, the watcher will go down the list

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -144,6 +144,10 @@ use it to find the project's name." docstring)
          (when (require ,feature nil t)
            ,@body)))))
 
+(activity-watch--gen-feature-resolver 'project project
+  (when (project-current)
+    (project-name (project-current))))
+
 (activity-watch--gen-feature-resolver 'projectile projectile
   (when (projectile-project-p)
        (projectile-project-name)))


### PR DESCRIPTION
Adds the functions `activity-watch-project-name-project` and `activity-watch-project-name-project-force` which use the built-in `project.el` package for getting the project name. Added it to the default list of resolvers behind `projectile`, because `project.el` is always available and when the user explicitly installs `projectile` for advanced functionality, projectile should be preferred. Added it in front of magit, because magit is no explicit project management package and thus should only be a fallback.