### PR TITLE
Fix invalid coding system on `recover-this-file`

### DIFF
--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -244,9 +244,9 @@ Argument TIME time at which the heartbeat was computed."
   (let ((now (float-time))
         (current-file-path (buffer-file-name (current-buffer)))
         (time-delta (+ (or activity-watch-last-heartbeat-time 0) activity-watch-max-heartbeat-per-sec))
-		(coding-system-for-read
-		 (unless (eq coding-system-for-read 'auto-save-coding)
-		   coding-system-for-read)))
+        (coding-system-for-read
+         (unless (eq coding-system-for-read 'auto-save-coding)
+           coding-system-for-read)))
     (if (or (not (string= (or activity-watch-last-file-path "") current-file-path))
             (< time-delta now))
         (progn

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -243,7 +243,10 @@ Argument TIME time at which the heartbeat was computed."
   (activity-watch--create-bucket)
   (let ((now (float-time))
         (current-file-path (buffer-file-name (current-buffer)))
-        (time-delta (+ (or activity-watch-last-heartbeat-time 0) activity-watch-max-heartbeat-per-sec)))
+        (time-delta (+ (or activity-watch-last-heartbeat-time 0) activity-watch-max-heartbeat-per-sec))
+		(coding-system-for-read
+		 (unless (eq coding-system-for-read 'auto-save-coding)
+		   coding-system-for-read)))
     (if (or (not (string= (or activity-watch-last-file-path "") current-file-path))
             (< time-delta now))
         (progn


### PR DESCRIPTION
This PR aims to fix #23. The same problem happened in wakatime-mode and @h2oota explained it [here](https://github.com/wakatime/wakatime-mode/issues/10#issuecomment-1905607164):

> 'auto-save-coding is a pseudo-coding-system used in (recover-file FILE). This error occurs when attempting to evaluate it > as a coding-system outside of the recover-file function.
> This occurs in wakatime-mode wakatime-call.

I just adapted their solution one to one. Now, in `activity-watch--call`, `coding-system-for-read` is effectively set to `nil` if it's not equal to `auto-save-coding`. For me and @benthamite this seems to work.

Fixes #23.