### PR TITLE
fix: function `first` does not exist

### DIFF
--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -150,7 +150,7 @@ use it to find the project's name." docstring)
         ;; `project-name' is a generic function added in Emacs 29.1
         (project-name project)
       ;; For earlier versions, use the generic function's default definition
-      (file-name-nondirectory (directory-file-name (first (project-roots project)))))))
+      (file-name-nondirectory (directory-file-name (car (project-roots project)))))))
 
 (activity-watch--gen-feature-resolver 'projectile projectile
   (when (projectile-project-p)


### PR DESCRIPTION
Use `car` instead of `first`, fixes #28.