### PR TITLE
feat: Add Org-mode clock property integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Set variable `activity-watch-api-host` to your activity watch local instance (de
 
 ### Project Name Detection
 
-By default, the extension will try to infer the name of the project by consulting Projectile and Magit. Users can add resolution methods by defining functions in the form =activity-watch-project-name-<NAME>= and then adding ='NAME= to the list of resolvers =activity-watch-project-name-resolvers=. See its documentation for a list of predefined resolvers.
+By default, the extension will try to infer the name of the project by consulting Projectile and Magit. Users can add resolution methods by defining functions in the form `activity-watch-project-name-<NAME>` and then adding `'NAME` to the list of resolvers `activity-watch-project-name-resolvers`. See its documentation for a list of predefined resolvers.
 
-The default project name used when a proper one cannot be determined is "unknown" and can be customized via =activity-watch-project-name-default=.
+The default project name used when a proper one cannot be determined is "unknown" and can be customized via `activity-watch-project-name-default`.
 
 ### Org-mode Integration (Optional)
 
@@ -56,7 +56,7 @@ Or if you use `use-package`:
   (global-activity-watch-mode))
 ```
 
-This is particularly useful for correlating time spent across different buffers (like =gptel=, =magit=, or source files) with a specific ticket or task ID defined in your Org files.
+This is particularly useful for correlating time spent across different buffers (like *gptel*, *magit*, or source files) with a specific ticket or task ID defined in your Org files.
 
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -27,9 +27,36 @@ Enable ActivityWatch for the current buffer by invoking `M-x activity-watch-mode
 
 Set variable `activity-watch-api-host` to your activity watch local instance (default to `http://localhost:5600`).
 
-By default, the extension will try to infer the name of the project by consulting Projectile and Magit. Users can add resolution methods by defining functions in the form `activity-watch-project-name-<NAME>` and then adding `'NAME` to the list of resolvers `activity-watch-project-name-resolvers`. See its documentation for a list of predefined resolvers.
+### Project Name Detection
 
-The default project name used when a proper one cannot be determined is "unknown" and can be customized via `activity-watch-project-name-default`.
+By default, the extension will try to infer the name of the project by consulting Projectile and Magit. Users can add resolution methods by defining functions in the form =activity-watch-project-name-<NAME>= and then adding ='NAME= to the list of resolvers =activity-watch-project-name-resolvers=. See its documentation for a list of predefined resolvers.
+
+The default project name used when a proper one cannot be determined is "unknown" and can be customized via =activity-watch-project-name-default=.
+
+### Org-mode Integration (Optional)
+
+You can automatically link your tracked time to specific Org-mode tasks. When an Org clock is active, the watcher can inject a specific property from the clocked task into the ActivityWatch payload.
+
+To enable this feature, add the following to your configuration:
+
+```elisp
+(setq activity-watch-org-clock-active t)
+(setq activity-watch-org-clock-property "TICKET_ID") ; Replace with your preferred property
+```
+
+Or if you use `use-package`:
+
+```elisp
+(use-package activity-watch-mode
+  :ensure t
+  :custom
+  (activity-watch-org-clock-active t)
+  (activity-watch-org-clock-property "TICKET_ID")
+  :config
+  (global-activity-watch-mode))
+```
+
+This is particularly useful for correlating time spent across different buffers (like =gptel=, =magit=, or source files) with a specific ticket or task ID defined in your Org files.
 
 
 ## Acknowledgments

--- a/activity-watch-mode.el
+++ b/activity-watch-mode.el
@@ -8,7 +8,7 @@
 ;; Homepage: https://github.com/pauldub/activity-watch-mode
 ;; Keywords: calendar, comm
 ;; Package-Requires: ((emacs "25") (request "0") (json "0") (cl-lib "0"))
-;; Version: 1.0.2
+;; Version: 1.0.3
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -74,6 +74,19 @@
   "Default name for a non-identifiable project."
   :type 'string
   :group 'activity-watch)
+
+(defcustom activity-watch-org-clock-active nil
+  "When non-nil, inject the active Org clock property into the payload.
+This allows ActivityWatch to track time spent on specific Org tasks."
+  :type 'boolean
+  :group 'activity-watch)
+
+(defcustom activity-watch-org-clock-property "TICKET_ID"
+  "The Org mode property to extract when the clock is active.
+The property name will be converted to lowercase and used as the JSON key."
+  :type 'string
+  :group 'activity-watch)
+
 
 (defcustom activity-watch-project-name-resolvers '(projectile project magit-dir-force magit-origin)
   "List of resolvers used to find the project name.
@@ -169,6 +182,20 @@ use it to find the project's name." docstring)
                                 ".git")))
     proj))
 
+(defun activity-watch--inject-org-property (heartbeat)
+  "Inject the active Org clock property into the ActivityWatch HEARTBEAT payload."
+  (when (and activity-watch-org-clock-active
+             (featurep 'org-clock)
+             (bound-and-true-p org-clock-marker)
+             (marker-buffer org-clock-marker))
+    (let* ((prop-name activity-watch-org-clock-property)
+           (prop-value (org-entry-get org-clock-marker prop-name))
+           (data-cell (assq 'data heartbeat)))
+      (when (and prop-value data-cell)
+        (let ((json-key (intern (downcase prop-name))))
+          (setcdr data-cell (cons (cons json-key prop-value) (cdr data-cell)))))))
+  heartbeat)
+
 (defun activity-watch-project-name-cwd ()
   "Return the name of the `default-directory'."
   (when default-directory
@@ -224,12 +251,13 @@ Argument TIME time at which the heartbeat was computed."
   (let ((project-name (activity-watch--get-project))
         (file-name (buffer-file-name (current-buffer)))
         (git-branch (when (fboundp 'magit-get-current-branch) (magit-get-current-branch))))
+   (activity-watch--inject-org-property
     `((timestamp . ,(ert--format-time-iso8601 time))
       (duration . 0)
       (data . ((language . ,(if (activity-watch--s-blank (symbol-name major-mode)) "unknown" major-mode))
                (project . ,project-name)
                (file . ,(if (activity-watch--s-blank file-name) "unknown" file-name))
-               (branch . ,(or git-branch "unknown")))))))
+               (branch . ,(or git-branch "unknown"))))))))
 
 (cl-defun activity-watch--send-heartbeat (heartbeat &key (on-error nil) (on-success nil))
   "Send HEARTBEAT to activity watch server, calling ON-ERROR on error and ON-SUCCESS on success."


### PR DESCRIPTION
Hi! I've been using `activity-watch-mode` and found it incredibly useful.
I'm submitting this PR to add an optional feature that allows users to
correlate their tracked time with specific Org-mode tasks.

### What this PR does:
It introduces the ability to extract a specific property (like `TICKET_ID`)
from an active Org-mode clock and inject it directly into the
ActivityWatch heartbeat payload.

This is particularly powerful because it allows time tracked across *any* 
buffer (Magit, eshell, vterm, or miscellaneous files) to be automatically 
attributed to the current active Org task in the ActivityWatch dashboard.

### Changes:
- Added `activity-watch-org-clock-active` (boolean) to toggle the feature.
- Added `activity-watch-org-clock-property` (string) to specify the property name.
- Implemented `activity-watch--inject-org-property` to handle metadata injection cleanly.
- Updated `README.md` with configuration instructions.

The feature is strictly opt-in and defaults to `nil`, so it won't affect 
the experience of users who don't need it.

Im hope you find this useful!